### PR TITLE
Search Provider for Global Search

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,9 +31,12 @@
                 android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.SEARCH" />
 
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
             </intent-filter>
+
+            <meta-data android:name="android.app.searchable" android:resource="@xml/searchable" />
         </activity>
 
         <activity
@@ -42,6 +45,13 @@
 
         <activity android:name=".activities.SearchActivity"/>
         <activity android:name=".activities.ArtistsAlbumsActivity"/>
+
+        <provider
+            android:name=".providers.SearchProvider"
+            android:authorities="com.sregg.android.tv.spotify"
+            android:enabled="true"
+            android:exported="true" >
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/sregg/android/tv/spotify/activities/MainActivity.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/activities/MainActivity.java
@@ -25,6 +25,10 @@ import com.spotify.sdk.android.authentication.AuthenticationResponse;
 import com.sregg.android.tv.spotify.R;
 import com.sregg.android.tv.spotify.SpotifyTvApplication;
 import com.sregg.android.tv.spotify.controllers.SpotifyPlayerController;
+import com.sregg.android.tv.spotify.utils.SpotifyUriLoader;
+
+import retrofit.RetrofitError;
+import retrofit.client.Response;
 
 /*
  * MainActivity class that loads MainFragment
@@ -47,6 +51,20 @@ public class MainActivity extends Activity {
 
     private void init() {
         setContentView(R.layout.activity_main);
+
+        if (getIntent() != null && getIntent().getData() != null) {
+            SpotifyUriLoader.loadObjectFromUri(SpotifyTvApplication.getInstance().getSpotifyService(), getIntent().getData().toString(), new SpotifyUriLoader.SpotifyObjectLoaderCallback() {
+                @Override
+                public void success(Object object, Response response) {
+                    SpotifyTvApplication.getInstance().onItemClick(MainActivity.this, object);
+                }
+
+                @Override
+                public void failure(RetrofitError error) {
+
+                }
+            });
+        }
     }
 
     private void login() {

--- a/app/src/main/java/com/sregg/android/tv/spotify/providers/SearchProvider.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/providers/SearchProvider.java
@@ -1,0 +1,167 @@
+package com.sregg.android.tv.spotify.providers;
+
+import android.app.SearchManager;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+
+import com.sregg.android.tv.spotify.Constants;
+import com.sregg.android.tv.spotify.R;
+import com.sregg.android.tv.spotify.SpotifyTvApplication;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import kaaes.spotify.webapi.android.SpotifyService;
+import kaaes.spotify.webapi.android.models.AlbumSimple;
+import kaaes.spotify.webapi.android.models.AlbumsPager;
+import kaaes.spotify.webapi.android.models.Artist;
+import kaaes.spotify.webapi.android.models.ArtistsPager;
+import kaaes.spotify.webapi.android.models.PlaylistSimple;
+import kaaes.spotify.webapi.android.models.PlaylistsPager;
+import kaaes.spotify.webapi.android.models.Track;
+import kaaes.spotify.webapi.android.models.TracksPager;
+
+public class SearchProvider extends ContentProvider {
+
+    private static final String[] CURSOR_COLUMNS = {
+            SearchManager.SUGGEST_COLUMN_TEXT_1, // Required
+            SearchManager.SUGGEST_COLUMN_CONTENT_TYPE, // Required
+            SearchManager.SUGGEST_COLUMN_PRODUCTION_YEAR, // Required
+            SearchManager.SUGGEST_COLUMN_RESULT_CARD_IMAGE,
+            SearchManager.SUGGEST_COLUMN_TEXT_2,
+            SearchManager.SUGGEST_COLUMN_DURATION,
+            SearchManager.SUGGEST_COLUMN_INTENT_DATA,
+    };
+
+    @Override
+    public String getType(Uri uri) {
+        return SearchManager.SUGGEST_MIME_TYPE;
+    }
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        String query = selectionArgs[0];
+        MatrixCursor cursor = new MatrixCursor(CURSOR_COLUMNS);
+
+        searchArtists(query, cursor);
+        searchAlbums(query, cursor);
+        searchTracks(query, cursor);
+        searchPlaylists(query, cursor);
+
+        return cursor;
+    }
+
+    private void searchArtists(String query, MatrixCursor cursor) {
+        ArtistsPager artistsPager = SpotifyTvApplication.getInstance().getSpotifyService().searchArtists(query, getSearchOptions());
+
+        if (artistsPager != null && artistsPager.artists != null) {
+            for (Artist artist : artistsPager.artists.items) {
+                MatrixCursor.RowBuilder row = cursor.newRow();
+
+                row.add(SearchManager.SUGGEST_COLUMN_TEXT_1, artist.name);
+                row.add(SearchManager.SUGGEST_COLUMN_CONTENT_TYPE, artist.type);
+                row.add(SearchManager.SUGGEST_COLUMN_INTENT_DATA, artist.uri);
+                row.add(SearchManager.SUGGEST_COLUMN_TEXT_2, getContext().getString(R.string.artists));
+
+                if (artist.images != null && artist.images.size() > 0) {
+                    row.add(SearchManager.SUGGEST_COLUMN_RESULT_CARD_IMAGE, artist.images.get(0).url);
+                }
+            }
+        }
+    }
+
+    private void searchAlbums(String query, MatrixCursor cursor) {
+        AlbumsPager albumsPager = SpotifyTvApplication.getInstance().getSpotifyService().searchAlbums(query, getSearchOptions());
+
+        if (albumsPager != null && albumsPager.albums != null) {
+            for (AlbumSimple album : albumsPager.albums.items) {
+                MatrixCursor.RowBuilder row = cursor.newRow();
+
+                row.add(SearchManager.SUGGEST_COLUMN_TEXT_1, album.name);
+                row.add(SearchManager.SUGGEST_COLUMN_CONTENT_TYPE, album.type);
+                row.add(SearchManager.SUGGEST_COLUMN_INTENT_DATA, album.uri);
+                row.add(SearchManager.SUGGEST_COLUMN_TEXT_2, getContext().getString(R.string.albums));
+
+                if (album.images != null && album.images.size() > 0) {
+                    row.add(SearchManager.SUGGEST_COLUMN_RESULT_CARD_IMAGE, album.images.get(0).url);
+                }
+            }
+        }
+    }
+
+    private void searchTracks(String query, MatrixCursor cursor) {
+        TracksPager tracksPager = SpotifyTvApplication.getInstance().getSpotifyService().searchTracks(query, getSearchOptions());
+
+        if (tracksPager != null && tracksPager.tracks != null) {
+            for (Track track : tracksPager.tracks.items) {
+                MatrixCursor.RowBuilder row = cursor.newRow();
+
+                row.add(SearchManager.SUGGEST_COLUMN_TEXT_1, track.name);
+                row.add(SearchManager.SUGGEST_COLUMN_CONTENT_TYPE, track.type);
+                row.add(SearchManager.SUGGEST_COLUMN_DURATION, track.duration_ms);
+                row.add(SearchManager.SUGGEST_COLUMN_INTENT_DATA, track.uri);
+
+                if (track.artists != null && track.artists.size() > 0) {
+                    row.add(SearchManager.SUGGEST_COLUMN_TEXT_2, track.artists.get(0).name);
+                }
+
+                if (track.album != null && track.album.images != null && track.album.images.size() > 0) {
+                    row.add(SearchManager.SUGGEST_COLUMN_RESULT_CARD_IMAGE, track.album.images.get(0).url);
+                }
+            }
+        }
+    }
+
+    private void searchPlaylists(String query, MatrixCursor cursor) {
+        PlaylistsPager playlistsPager = SpotifyTvApplication.getInstance().getSpotifyService().searchPlaylists(query, getSearchOptions());
+
+        if (playlistsPager != null && playlistsPager.playlists != null) {
+            for (PlaylistSimple playlist : playlistsPager.playlists.items) {
+                MatrixCursor.RowBuilder row = cursor.newRow();
+
+                row.add(SearchManager.SUGGEST_COLUMN_TEXT_1, playlist.name);
+                row.add(SearchManager.SUGGEST_COLUMN_CONTENT_TYPE, playlist.type);
+                row.add(SearchManager.SUGGEST_COLUMN_INTENT_DATA, playlist.uri);
+                row.add(SearchManager.SUGGEST_COLUMN_TEXT_2, getContext().getString(R.string.playlists));
+
+                if (playlist.images != null && playlist.images.size() > 0) {
+                    row.add(SearchManager.SUGGEST_COLUMN_RESULT_CARD_IMAGE, playlist.images.get(0).url);
+                }
+            }
+        }
+    }
+
+    private Map<String, Object> getSearchOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(SpotifyService.MARKET, Constants.MARKET_FROM_TOKEN);
+        return options;
+    }
+
+    /* Below are Provider Methods not used by search */
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        // TODO: Implement this to handle requests to insert a new row.
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        // TODO: Implement this to handle requests to update one or more rows.
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        // Implement this to handle requests to delete one or more rows.
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/utils/SpotifyUriLoader.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/utils/SpotifyUriLoader.java
@@ -1,0 +1,116 @@
+package com.sregg.android.tv.spotify.utils;
+
+import com.sregg.android.tv.spotify.SpotifyTvApplication;
+
+import kaaes.spotify.webapi.android.SpotifyService;
+import kaaes.spotify.webapi.android.models.Album;
+import kaaes.spotify.webapi.android.models.Artist;
+import kaaes.spotify.webapi.android.models.Playlist;
+import kaaes.spotify.webapi.android.models.Track;
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+public class SpotifyUriLoader {
+
+    private static final String ALBUM_URI = "spotify:album:";
+    private static final String ARTIST_URI = "spotify:artist:";
+    private static final String TRACK_URI = "spotify:track:";
+    private static final String USER_URI = "spotify:user:";
+    private static final String USER_PLAYLIST_URI = ":playlist:";
+
+    public static void loadObjectFromUri(final SpotifyService service, final String uri, final SpotifyObjectLoaderCallback callback) {
+        if (uri.startsWith(ALBUM_URI)) {
+            loadAlbumFromUri(service, uri, callback);
+        } else if (uri.startsWith(ARTIST_URI)) {
+            loadArtistFromUri(service, uri, callback);
+        } else if (uri.startsWith(USER_URI) && uri.contains(USER_PLAYLIST_URI)) {
+            loadPlaylistFromUri(service, uri, callback);
+        } else if (uri.startsWith(TRACK_URI)) {
+            loadTrackFromUri(service, uri, callback);
+        }
+    }
+
+    private static void loadAlbumFromUri(SpotifyService service, String uri, final SpotifyObjectLoaderCallback callback) {
+        SpotifyTvApplication.getInstance().getSpotifyService().getAlbum(uri.replace(ALBUM_URI, ""), new Callback<Album>() {
+            @Override
+            public void success(Album album, Response response) {
+                if (callback != null) {
+                    callback.success(album, response);
+                }
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+                if (callback != null) {
+                    callback.failure(error);
+                }
+            }
+        });
+    }
+
+    private static void loadArtistFromUri(SpotifyService service, String uri, final SpotifyObjectLoaderCallback callback) {
+        SpotifyTvApplication.getInstance().getSpotifyService().getArtist(uri.replace(ARTIST_URI, ""), new Callback<Artist>() {
+            @Override
+            public void success(Artist artist, Response response) {
+                if (callback != null) {
+                    callback.success(artist, response);
+                }
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+                if (callback != null) {
+                    callback.failure(error);
+                }
+            }
+        });
+    }
+
+    private static void loadPlaylistFromUri(SpotifyService service, String uri, final SpotifyObjectLoaderCallback callback) {
+        String[] uriParts = uri.split(USER_PLAYLIST_URI);
+        if (uriParts.length == 2) {
+            String userId = uriParts[0].replace(USER_URI, "");
+            String playlistId = uriParts[1];
+            SpotifyTvApplication.getInstance().getSpotifyService().getPlaylist(userId, playlistId, new Callback<Playlist>() {
+                @Override
+                public void success(Playlist playlist, Response response) {
+                    if (callback != null) {
+                        callback.success(playlist, response);
+                    }
+                }
+
+                @Override
+                public void failure(RetrofitError error) {
+                    if (callback != null) {
+                        callback.failure(error);
+                    }
+                }
+            });
+        }
+    }
+
+    private static void loadTrackFromUri(SpotifyService service, String uri, final SpotifyObjectLoaderCallback callback) {
+        SpotifyTvApplication.getInstance().getSpotifyService().getTrack(uri.replace(TRACK_URI, ""), new Callback<Track>() {
+            @Override
+            public void success(Track track, Response response) {
+                if (callback != null) {
+                    callback.success(track, response);
+                }
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+                if (callback != null) {
+                    callback.failure(error);
+                }
+            }
+        });
+    }
+
+    public interface SpotifyObjectLoaderCallback {
+        public void success(Object object, Response response);
+        public void failure(RetrofitError error);
+    }
+
+}

--- a/app/src/main/res/xml/searchable.xml
+++ b/app/src/main/res/xml/searchable.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<searchable xmlns:android="http://schemas.android.com/apk/res/android"
+    android:label="@string/app_name"
+    android:hint="@string/app_name"
+    android:searchSettingsDescription="@string/app_name"
+    android:searchSuggestAuthority="com.sregg.android.tv.spotify"
+    android:searchSuggestIntentAction="android.intent.action.VIEW"
+    android:searchSuggestIntentData="content://com.sregg.android.tv.spotify/search"
+    android:searchSuggestSelection=" ?"
+    android:searchSuggestThreshold="1"
+    android:includeInGlobalSearch="true"
+    >
+</searchable>


### PR DESCRIPTION
This enables search results for the app in the Global Search. Results are presented in the following order for the query phrase: artists, albums, tracks, playlists.

I will use the handling of data uri in the intent for the different object types to add Recommendations as well.

There are currently some limitations. The app must've been started and running in the background for the search to work. This is due to how the API service and mostly auth token is handled in the app. If the auth token is persisted and the service can be used without having to do the auth phase in the Main Activity this can be fixed easily.

Develop seems to be out of sync with master but I can change to develop if needed

![spotify-tv-search](https://cloud.githubusercontent.com/assets/288631/7551976/f6c7255c-f69c-11e4-9fe4-585a2ef13d8d.png)
