### PR TITLE
Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea/libraries
 .DS_Store
 /build
+release.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: android
+android:
+  components:
+    - build-tools-21.1.2
+    - android-21
+    - extra-google-m2repository
+    - extra-android-m2repository
+script:
+  - ./gradlew build assembleDebug

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Unofficial Spotify app for Android TV
 - [Global Search](https://developer.android.com/training/tv/discovery/searchable.html) WIP by @Dahlgren [here](https://github.com/sregg/spotify-tv/pull/1)
 - [Bitrate Settings](https://developer.spotify.com/android-sdk-docs/com/spotify/sdk/android/playback/Player.html#setPlaybackBitrate-com.spotify.sdk.android.playback.PlaybackBitrate-)
 
+# Release build
+Add the values `release.storeFile`, `release.storePassword`, `release.keyAlias`, and `release.keyPassword` to `release.properties`.
+`release.storeFile` should be an absolute path to your keystore, the others should be the string value.
+See `release.properties.sample` for an example file.
+
 # Pull Requests
 I welcome and encourage all pull requests. 
 It usually will take me within 24-48 hours to respond to any issue or request. 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,4 +83,5 @@ if (project.rootProject.file('release.properties').exists()) {
     }
 } else {
     project.logger.warn('WARN: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    android.buildTypes.release.signingConfig = null
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,13 +13,11 @@ buildscript {
 }
 
 android {
+    lintOptions {
+        abortOnError false
+    }
     signingConfigs {
-        release {
-            storeFile file('/Users/simonreggiani/Documents/dev/keys/android_keystore.key')
-            storePassword file("/Users/simonreggiani/Documents/dev/keys/android_keystore.txt").readLines().get(1)
-            keyAlias file("/Users/simonreggiani/Documents/dev/keys/android_keystore.txt").readLines().get(0)
-            keyPassword file("/Users/simonreggiani/Documents/dev/keys/android_keystore.txt").readLines().get(1)
-        }
+        release
     }
     compileSdkVersion 21
     buildToolsVersion "21.1.2"
@@ -66,4 +64,23 @@ dependencies {
 play {
     serviceAccountEmail = '724462887271-bk4vi27q9qk9h4g3mideokj3e0bqe3ng@developer.gserviceaccount.com'
     pk12File = file('/Users/simonreggiani/Documents/dev/keys/Google_Play_Android_Developer-0bc22be971a2.p12')
+}
+
+Properties releaseProperties = new Properties()
+if (project.rootProject.file('release.properties').exists()) {
+    releaseProperties.load(project.rootProject.file('release.properties').newDataInputStream())
+    if (releaseProperties.getProperty('storeFile') &&
+            releaseProperties.getProperty('storePassword') &&
+            releaseProperties.getProperty('keyAlias') &&
+            releaseProperties.getProperty('keyPassword')) {
+        android.signingConfigs.release.storeFile = file(releaseProperties.getProperty('storeFile'))
+        android.signingConfigs.release.storePassword = releaseProperties.getProperty('storePassword')
+        android.signingConfigs.release.keyAlias = releaseProperties.getProperty('keyAlias')
+        android.signingConfigs.release.keyPassword = releaseProperties.getProperty('keyPassword')
+    } else {
+        project.logger.warn('WARN: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+        android.buildTypes.release.signingConfig = null
+    }
+} else {
+    project.logger.warn('WARN: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
 }

--- a/release.properties.sample
+++ b/release.properties.sample
@@ -1,0 +1,4 @@
+storeFile=/Users/someuser/.android/debug.keystore
+storePassword=android
+keyAlias=androiddebugkey
+keyPassword=android


### PR DESCRIPTION
This adds Travis CI configuration to the repository. Travis CI for open source project is free and will not cost your a dime. Builds will be trigged for commits pushed directly to your repo i.e. by you and also all pull requests submitted by others. Travis CI will notify if a build fails and will add a nice icon to the commit with the build result and/or show a message indicating if the code can be successfully built after a pull request merge or not. It will currently build the debug configuration and check for any code issues. This can of course be extended to run unit tests, lint the code, check formatting or run other Java analytic tools. Travis CI could also automatically upload new builds to Google Play, HockeyApp or other services, both for release or for limited testers.

To enable Travis CI for this repository, go to https://travis-ci.org/, login with your Github account and add this repository. Here's the build history for Travis CI builds on my forked repository, https://travis-ci.org/Dahlgren/spotify-tv

It is not required that people who fork your build to enable Travis CI for their accounts. Pull requests sent by other will be built by Travis CI once the create the pull request to your repo.

Current build status can also be added to the README file. See http://docs.travis-ci.com/user/status-images/. Example for my forked repo,
[![Build Status](https://travis-ci.org/Dahlgren/spotify-tv.svg?branch=feature%2Ftravis-ci)](https://travis-ci.org/Dahlgren/spotify-tv)

To avoid issues with the release configuration in the build.gradle file the values has been moved to release.properties. The file is added to gitignore. This also eases work for new contributors since the current build.gradle file fails to load in Android Studio. I hope this isn't an issue for you.
