### PR TITLE
Details view for Album and Playlist

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,8 @@
 
         <activity android:name=".activities.SearchActivity"/>
         <activity android:name=".activities.ArtistsAlbumsActivity"/>
+        <activity android:name=".activities.AlbumActivity"/>
+        <activity android:name=".activities.PlaylistActivity"/>
 
         <provider
             android:name=".providers.SearchProvider"

--- a/app/src/main/java/com/sregg/android/tv/spotify/SpotifyTvApplication.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/SpotifyTvApplication.java
@@ -5,14 +5,19 @@ import android.app.Application;
 import com.spotify.sdk.android.player.Config;
 import com.spotify.sdk.android.player.Player;
 import com.spotify.sdk.android.player.Spotify;
+import com.sregg.android.tv.spotify.activities.AlbumActivity;
 import com.sregg.android.tv.spotify.activities.ArtistsAlbumsActivity;
+import com.sregg.android.tv.spotify.activities.PlaylistActivity;
 import com.sregg.android.tv.spotify.controllers.SpotifyPlayerController;
 import com.sregg.android.tv.spotify.enums.Control;
 import com.sregg.android.tv.spotify.settings.Setting;
 import com.sregg.android.tv.spotify.utils.Utils;
 import kaaes.spotify.webapi.android.SpotifyApi;
 import kaaes.spotify.webapi.android.SpotifyService;
+import kaaes.spotify.webapi.android.models.AlbumSimple;
 import kaaes.spotify.webapi.android.models.ArtistSimple;
+import kaaes.spotify.webapi.android.models.Playlist;
+import kaaes.spotify.webapi.android.models.PlaylistBase;
 import kaaes.spotify.webapi.android.models.User;
 
 /**
@@ -87,9 +92,15 @@ public class SpotifyTvApplication extends Application {
             ((Setting) item).onClick(activity);
         } else if (item instanceof Control) {
             getSpotifyPlayerController().onControlClick(((Control) item));
+        } else if (item instanceof AlbumSimple) {
+            AlbumSimple albumSimple = (AlbumSimple) item;
+            AlbumActivity.launch(activity, albumSimple.id, albumSimple.name);
         } else if (item instanceof ArtistSimple) {
             ArtistSimple artistSimple = (ArtistSimple) item;
             ArtistsAlbumsActivity.launch(activity, artistSimple.id, artistSimple.name);
+        } else if (item instanceof PlaylistBase) {
+            PlaylistBase playlist = (PlaylistBase) item;
+            PlaylistActivity.launch(activity, playlist.id, playlist.name, playlist.owner.id);
         } else {
             String itemUri = Utils.getUriFromSpotiyObject(item);
             if (itemUri.equals(mSpotifyPlayerController.getCurrentObjectUri())) {

--- a/app/src/main/java/com/sregg/android/tv/spotify/activities/AlbumActivity.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/activities/AlbumActivity.java
@@ -1,0 +1,35 @@
+package com.sregg.android.tv.spotify.activities;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.sregg.android.tv.spotify.R;
+
+import kaaes.spotify.webapi.android.models.AlbumSimple;
+
+/*
+ * AlbumActivity for AlbumDetailsFragment
+ */
+public class AlbumActivity extends Activity {
+
+    public static final String ARG_ALBUM_ID = "ARG_ALBUM_ID";
+    public static final String ARG_ALBUM_NAME = "ARG_ALBUM_NAME";
+
+    /**
+     * Called when the activity is first created.
+     */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_album);
+    }
+
+    public static void launch(Activity activity, String id, String name) {
+        Intent intent = new Intent(activity, AlbumActivity.class);
+        intent.putExtra(ARG_ALBUM_ID, id);
+        intent.putExtra(ARG_ALBUM_NAME, name);
+        activity.startActivity(intent);
+    }
+
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/activities/PlaylistActivity.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/activities/PlaylistActivity.java
@@ -1,0 +1,35 @@
+package com.sregg.android.tv.spotify.activities;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.sregg.android.tv.spotify.R;
+
+/*
+ * PlaylistActivity for PlaylistDetailsFragment
+ */
+public class PlaylistActivity extends Activity {
+
+    public static final String ARG_PLAYLIST_ID = "ARG_PLAYLIST_ID";
+    public static final String ARG_PLAYLIST_NAME = "ARG_PLAYLIST_NAME";
+    public static final String ARG_USER_ID = "ARG_USER_ID";
+
+    /**
+     * Called when the activity is first created.
+     */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_playlist);
+    }
+
+    public static void launch(Activity activity, String id, String name, String userId) {
+        Intent intent = new Intent(activity, PlaylistActivity.class);
+        intent.putExtra(ARG_PLAYLIST_ID, id);
+        intent.putExtra(ARG_PLAYLIST_NAME, name);
+        intent.putExtra(ARG_USER_ID, userId);
+        activity.startActivity(intent);
+    }
+
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/controllers/SpotifyPlayerController.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/controllers/SpotifyPlayerController.java
@@ -20,6 +20,7 @@ import kaaes.spotify.webapi.android.models.Pager;
 import kaaes.spotify.webapi.android.models.Playlist;
 import kaaes.spotify.webapi.android.models.PlaylistSimple;
 import kaaes.spotify.webapi.android.models.Track;
+import kaaes.spotify.webapi.android.models.TrackSimple;
 import retrofit.Callback;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
@@ -67,7 +68,7 @@ public class SpotifyPlayerController implements PlayerNotificationCallback, Conn
     public void play(Object spotifyObject) {
         mCurrentSpotifyObject = spotifyObject;
 
-        if (spotifyObject instanceof Track || spotifyObject instanceof Playlist ||  spotifyObject instanceof PlaylistSimple) {
+        if (spotifyObject instanceof TrackSimple || spotifyObject instanceof Playlist ||  spotifyObject instanceof PlaylistSimple) {
             mPlayer.play(getCurrentObjectUri());
         } else if (spotifyObject instanceof AlbumSimple) {
             // get album's tracks

--- a/app/src/main/java/com/sregg/android/tv/spotify/fragments/AlbumDetailsFragment.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/fragments/AlbumDetailsFragment.java
@@ -1,0 +1,124 @@
+package com.sregg.android.tv.spotify.fragments;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v17.leanback.widget.Action;
+import android.support.v17.leanback.widget.DetailsOverviewRow;
+import android.support.v17.leanback.widget.OnActionClickedListener;
+import android.support.v17.leanback.widget.Presenter;
+import android.util.Log;
+
+import com.sregg.android.tv.spotify.R;
+import com.sregg.android.tv.spotify.SpotifyTvApplication;
+import com.sregg.android.tv.spotify.activities.AlbumActivity;
+import com.sregg.android.tv.spotify.activities.ArtistsAlbumsActivity;
+import com.sregg.android.tv.spotify.presenters.AlbumDetailsPresenter;
+import com.sregg.android.tv.spotify.presenters.AlbumTrackRowPresenter;
+
+import kaaes.spotify.webapi.android.SpotifyService;
+import kaaes.spotify.webapi.android.models.Album;
+import kaaes.spotify.webapi.android.models.ArtistSimple;
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+public class AlbumDetailsFragment extends TracksDetailsFragment {
+
+    private static final String TAG = AlbumDetailsFragment.class.getSimpleName();
+
+    private static final long ACTION_PLAY_ALBUM = 1;
+    private static final long ACTION_VIEW_ARTIST = 2;
+
+    private SpotifyService mSpotifyService;
+    private SpotifyTvApplication mApp;
+
+    private String mAlbumId;
+    private Album mAlbum;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        Log.d(TAG, "onCreate");
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getActivity().getIntent();
+
+        mAlbumId = intent.getStringExtra(AlbumActivity.ARG_ALBUM_ID);
+
+        mApp = SpotifyTvApplication.getInstance();
+        mSpotifyService = mApp.getSpotifyService();
+
+        setupFragment();
+        loadAlbum();
+    }
+
+    @Override
+    protected Presenter getDetailsPresenter() {
+        return new AlbumDetailsPresenter();
+    }
+
+    @Override
+    protected Presenter getTrackRowPresenter() {
+        return new AlbumTrackRowPresenter();
+    }
+
+    private void setupFragment() {
+        setOnActionClickedListener(new OnActionClickedListener() {
+            @Override
+            public void onActionClicked(Action action) {
+                if (action.getId() == ACTION_PLAY_ALBUM) {
+                    mApp.getSpotifyPlayerController().play(mAlbum);
+                } else if (action.getId() == ACTION_VIEW_ARTIST) {
+                    ArtistSimple artist = null;
+
+                    if (mAlbum.artists.size() > 0) {
+                        artist = mAlbum.artists.get(0);
+                    }
+
+                    if (artist != null) {
+                        ArtistsAlbumsActivity.launch(getActivity(), artist.id, artist.name);
+                    }
+                }
+            }
+        });
+    }
+
+    private void loadAlbum() {
+        // load artist from API to get their image
+        mSpotifyService.getAlbum(mAlbumId, new Callback<Album>() {
+            @Override
+            public void success(final Album album, Response response) {
+                mAlbum = album;
+                setupDetails(album);
+                setupTracksRows(album.tracks.items);
+
+                if (album.images.size() > 0) {
+                    String imageUrl = album.images.get(0).url;
+                    loadBackgroundImage(imageUrl);
+                    loadDetailsRowImage(imageUrl);
+                }
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+
+            }
+        });
+    }
+
+    private void setupDetails(Album album) {
+        DetailsOverviewRow detailsRow = new DetailsOverviewRow(album);
+
+        detailsRow.addAction(new Action(
+                ACTION_PLAY_ALBUM,
+                getResources().getString(R.string.lb_playback_controls_play),
+                null,
+                getActivity().getDrawable(R.drawable.lb_ic_play)
+        ));
+        detailsRow.addAction(new Action(
+                ACTION_VIEW_ARTIST, getResources().getString(R.string.go_to_artist),
+                null
+        ));
+
+        setDetailsRow(detailsRow);
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/fragments/PlaylistDetailsFragment.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/fragments/PlaylistDetailsFragment.java
@@ -1,0 +1,119 @@
+package com.sregg.android.tv.spotify.fragments;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v17.leanback.widget.Action;
+import android.support.v17.leanback.widget.DetailsOverviewRow;
+import android.support.v17.leanback.widget.OnActionClickedListener;
+import android.support.v17.leanback.widget.Presenter;
+import android.util.Log;
+
+import com.sregg.android.tv.spotify.R;
+import com.sregg.android.tv.spotify.SpotifyTvApplication;
+import com.sregg.android.tv.spotify.activities.PlaylistActivity;
+import com.sregg.android.tv.spotify.presenters.PlaylistDetailsPresenter;
+import com.sregg.android.tv.spotify.presenters.PlaylistTrackRowPresenter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import kaaes.spotify.webapi.android.SpotifyService;
+import kaaes.spotify.webapi.android.models.Playlist;
+import kaaes.spotify.webapi.android.models.PlaylistTrack;
+import kaaes.spotify.webapi.android.models.TrackSimple;
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+public class PlaylistDetailsFragment extends TracksDetailsFragment {
+
+    private static final String TAG = PlaylistDetailsFragment.class.getSimpleName();
+
+    private static final long ACTION_PLAY_PLAYLIST = 1;
+
+    private SpotifyService mSpotifyService;
+    private SpotifyTvApplication mApp;
+
+    private String mPlaylistId;
+    private String mUserId;
+    private Playlist mPlaylist;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        Log.d(TAG, "onCreate");
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getActivity().getIntent();
+
+        mPlaylistId = intent.getStringExtra(PlaylistActivity.ARG_PLAYLIST_ID);
+        mUserId = intent.getStringExtra(PlaylistActivity.ARG_USER_ID);
+
+        mApp = SpotifyTvApplication.getInstance();
+        mSpotifyService = mApp.getSpotifyService();
+
+        setupFragment();
+        loadPlaylist();
+    }
+
+    @Override
+    protected Presenter getDetailsPresenter() {
+        return new PlaylistDetailsPresenter();
+    }
+
+    @Override
+    protected Presenter getTrackRowPresenter() {
+        return new PlaylistTrackRowPresenter();
+    }
+
+    private void setupFragment() {
+        setOnActionClickedListener(new OnActionClickedListener() {
+            @Override
+            public void onActionClicked(Action action) {
+                if (action.getId() == ACTION_PLAY_PLAYLIST) {
+                    mApp.getSpotifyPlayerController().play(mPlaylist);
+                }
+            }
+        });
+    }
+
+    private void loadPlaylist() {
+        // load artist from API to get their image
+        mSpotifyService.getPlaylist(mUserId, mPlaylistId, new Callback<Playlist>() {
+            @Override
+            public void success(final Playlist playlist, Response response) {
+                mPlaylist = playlist;
+                setupDetails(playlist);
+
+                List<TrackSimple> tracks = new ArrayList<TrackSimple>();
+                for (PlaylistTrack playlistTrack : playlist.tracks.items) {
+                    tracks.add(playlistTrack.track);
+                }
+                setupTracksRows(tracks);
+
+                if (playlist.images.size() > 0) {
+                    String imageUrl = playlist.images.get(0).url;
+                    loadBackgroundImage(imageUrl);
+                    loadDetailsRowImage(imageUrl);
+                }
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+
+            }
+        });
+    }
+
+    private void setupDetails(Playlist playlist) {
+        DetailsOverviewRow detailsRow = new DetailsOverviewRow(playlist);
+
+        detailsRow.addAction(new Action(
+                ACTION_PLAY_PLAYLIST,
+                getResources().getString(R.string.lb_playback_controls_play),
+                null,
+                getActivity().getDrawable(R.drawable.lb_ic_play)
+        ));
+
+        setDetailsRow(detailsRow);
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/fragments/TracksDetailsFragment.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/fragments/TracksDetailsFragment.java
@@ -1,0 +1,196 @@
+package com.sregg.android.tv.spotify.fragments;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v17.leanback.app.BackgroundManager;
+import android.support.v17.leanback.app.DetailsFragment;
+import android.support.v17.leanback.widget.ArrayObjectAdapter;
+import android.support.v17.leanback.widget.ClassPresenterSelector;
+import android.support.v17.leanback.widget.DetailsOverviewRow;
+import android.support.v17.leanback.widget.DetailsOverviewRowPresenter;
+import android.support.v17.leanback.widget.OnActionClickedListener;
+import android.support.v17.leanback.widget.OnItemViewClickedListener;
+import android.support.v17.leanback.widget.Presenter;
+import android.support.v17.leanback.widget.Row;
+import android.support.v17.leanback.widget.RowPresenter;
+import android.support.v7.graphics.Palette;
+import android.util.DisplayMetrics;
+import android.util.Log;
+
+import com.squareup.picasso.Picasso;
+import com.squareup.picasso.Target;
+import com.sregg.android.tv.spotify.SpotifyTvApplication;
+import com.sregg.android.tv.spotify.presenters.AlbumTrackRowPresenter;
+import com.sregg.android.tv.spotify.presenters.TracksHeaderRowPresenter;
+import com.sregg.android.tv.spotify.rows.TrackRow;
+import com.sregg.android.tv.spotify.rows.TracksHeaderRow;
+import com.sregg.android.tv.spotify.utils.BlurTransformation;
+import com.sregg.android.tv.spotify.utils.Utils;
+
+import java.io.IOException;
+import java.util.List;
+
+import kaaes.spotify.webapi.android.models.TrackSimple;
+
+public abstract class TracksDetailsFragment extends DetailsFragment {
+    private static final String TAG = TracksDetailsFragment.class.getSimpleName();
+
+    private static final int DETAIL_THUMB_WIDTH = 274;
+    private static final int DETAIL_THUMB_HEIGHT = 274;
+
+    private BackgroundManager mBackgroundManager;
+    private DisplayMetrics mMetrics;
+    private Handler mHandler;
+    private ArrayObjectAdapter mRowsAdapter;
+    private SpotifyTvApplication mApp;
+
+    private OnActionClickedListener mOnActionClickedListener;
+
+    private DetailsOverviewRowPresenter mDetailsPresenter;
+    private DetailsOverviewRow mDetailsRow;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        Log.d(TAG, "onCreate");
+        super.onCreate(savedInstanceState);
+
+        mHandler = new Handler();
+
+        mApp = SpotifyTvApplication.getInstance();
+
+        setupFragment();
+        setupBackground();
+    }
+
+    protected abstract Presenter getDetailsPresenter();
+
+    protected abstract Presenter getTrackRowPresenter();
+
+    private void setupFragment() {
+        mDetailsPresenter = new DetailsOverviewRowPresenter(getDetailsPresenter());
+        mDetailsPresenter.setStyleLarge(false);
+
+        ClassPresenterSelector ps = new ClassPresenterSelector();
+        ps.addClassPresenter(DetailsOverviewRow.class, mDetailsPresenter);
+        ps.addClassPresenter(TracksHeaderRow.class, new TracksHeaderRowPresenter());
+        ps.addClassPresenter(TrackRow.class, getTrackRowPresenter());
+
+        setOnItemViewClickedListener(new OnItemViewClickedListener() {
+            @Override
+            public void onItemClicked(Presenter.ViewHolder itemViewHolder, Object item, RowPresenter.ViewHolder rowViewHolder, Row row) {
+                if (item instanceof TrackSimple) {
+                    mApp.onItemClick(getActivity(), item);
+                }
+            }
+        });
+
+        mRowsAdapter = new ArrayObjectAdapter(ps);
+        setAdapter(mRowsAdapter);
+    }
+
+    private void setupBackground() {
+        mBackgroundManager = BackgroundManager.getInstance(getActivity());
+        mBackgroundManager.attach(getActivity().getWindow());
+        mMetrics = new DisplayMetrics();
+        getActivity().getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+    }
+
+    protected void setOnActionClickedListener(OnActionClickedListener listener) {
+        mDetailsPresenter.setOnActionClickedListener(listener);
+    }
+
+    protected void setDetailsRow(DetailsOverviewRow row) {
+        mDetailsRow = row;
+        mRowsAdapter.add(0, mDetailsRow);
+    }
+
+    protected void setupTracksRows(List<TrackSimple> tracks) {
+        mRowsAdapter.add(new TracksHeaderRow());
+        for (TrackSimple track : tracks) {
+            mRowsAdapter.add(new TrackRow(track));
+        }
+    }
+
+    protected void loadBackgroundImage(final String imageUrl) {
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                Picasso.with(getActivity())
+                        .load(imageUrl)
+                        .transform(new BlurTransformation(getActivity()))
+                        .resize(mMetrics.widthPixels, mMetrics.heightPixels)
+                        .centerCrop()
+                        .into(new BackgroundTarget());
+            }
+        });
+    }
+
+    protected void loadDetailsRowImage(String imageUrl) {
+        new DetailRowImageLoader().execute(imageUrl);
+    }
+
+    private class DetailRowImageLoader extends AsyncTask<String, Void, Void> {
+
+        @Override
+        protected Void doInBackground(String... params) {
+            Bitmap cover = null;
+            try {
+                cover = Picasso.with(getActivity())
+                        .load(params[0])
+                        .resize(
+                                Utils.dpToPx(DETAIL_THUMB_WIDTH, getActivity()),
+                                Utils.dpToPx(DETAIL_THUMB_HEIGHT, getActivity())
+                        )
+                        .centerCrop()
+                        .get();
+
+                mDetailsRow.setImageBitmap(getActivity(), cover);
+
+                Palette palette = Palette.generate(cover);
+                Palette.Swatch swatch = palette.getDarkVibrantSwatch();
+
+                if (swatch == null) {
+                    swatch = palette.getDarkMutedSwatch();
+                }
+
+                if (swatch != null) {
+                    mDetailsPresenter.setBackgroundColor(swatch.getRgb());
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            setAdapter(mRowsAdapter);
+        }
+    }
+
+    private class BackgroundTarget implements Target {
+        @Override
+        public void onBitmapLoaded(final Bitmap bitmap, Picasso.LoadedFrom from) {
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    mBackgroundManager.setBitmap(bitmap);
+                }
+            });
+        }
+
+        @Override
+        public void onBitmapFailed(Drawable errorDrawable) {
+
+        }
+
+        @Override
+        public void onPrepareLoad(Drawable placeHolderDrawable) {
+
+        }
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/presenters/AbsTrackRowPresenter.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/presenters/AbsTrackRowPresenter.java
@@ -1,0 +1,105 @@
+package com.sregg.android.tv.spotify.presenters;
+
+import android.support.v17.leanback.widget.RowPresenter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.sregg.android.tv.spotify.R;
+import com.sregg.android.tv.spotify.SpotifyTvApplication;
+import com.sregg.android.tv.spotify.rows.TrackRow;
+import com.sregg.android.tv.spotify.utils.Utils;
+import com.sregg.android.tv.spotify.views.TrackRowView;
+
+public abstract class AbsTrackRowPresenter extends RowPresenter {
+    private static final String TAG = "TrackRowPresenter";
+
+    static class TrackRowViewHolder extends ViewHolder {
+
+        protected final TrackRowView mTrackRowView;
+
+        public TrackRowViewHolder(TrackRowView trackRowView) {
+            super(trackRowView);
+            mTrackRowView = trackRowView;
+        }
+
+        public TextView getArtistTextView() {
+            return mTrackRowView.getArtistTextView();
+        }
+
+        public TextView getTrackTextView() {
+            return mTrackRowView.getTrackTextView();
+        }
+
+        public TextView getTrackLengthTextView() {
+            return mTrackRowView.getTrackLengthTextView();
+        }
+
+        public TextView getTrackNumberTextView() {
+            return mTrackRowView.getTrackNumberTextView();
+        }
+    }
+
+    public AbsTrackRowPresenter() {
+        super();
+
+        setHeaderPresenter(null);
+    }
+
+    @Override
+    public TrackRowViewHolder createRowViewHolder(ViewGroup parent) {
+        TrackRowView view = (TrackRowView) LayoutInflater.from(parent.getContext()).inflate(R.layout.track_row_view, parent, false);
+        return new TrackRowViewHolder(view);
+    }
+
+    @Override
+    protected void onBindRowViewHolder(RowPresenter.ViewHolder viewHolder, Object item) {
+        super.onBindRowViewHolder(viewHolder, item);
+
+        final TrackRowViewHolder trackViewHolder = (TrackRowViewHolder) viewHolder;
+        final TrackRowView trackRowview = trackViewHolder.mTrackRowView;
+        final TrackRow trackRow = (TrackRow) item;
+
+        // get uri
+        String uri = Utils.getUriFromSpotiyObject(trackRow.getTrack());
+        trackRowview.setUri(uri);
+
+        // init badge and now playing
+        String currentObjectUri = SpotifyTvApplication.getInstance().getSpotifyPlayerController().getCurrentObjectUri();
+        trackRowview.initNowPlaying(uri != null && uri.equals(currentObjectUri));
+
+        trackRowview.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (getOnItemClickedListener() != null) {
+                    getOnItemClickedListener().onItemClicked(trackRow.getTrack(), trackRow);
+                }
+
+                if (getOnItemViewClickedListener() != null) {
+                    getOnItemViewClickedListener().onItemClicked(trackViewHolder, trackRow.getTrack(), trackViewHolder, trackRow);
+                }
+            }
+        });
+    }
+
+    @Override
+    protected void onUnbindRowViewHolder(RowPresenter.ViewHolder viewHolder) {
+        super.onUnbindRowViewHolder(viewHolder);
+
+        TrackRowViewHolder cardViewHolder = (TrackRowViewHolder) viewHolder;
+
+        TrackRowView trackRowview = cardViewHolder.mTrackRowView;
+    }
+
+    @Override
+    protected void onRowViewSelected(RowPresenter.ViewHolder holder, boolean selected) {
+        super.onRowViewSelected(holder, selected);
+        ViewHolder vh = (ViewHolder) holder;
+    }
+
+    @Override
+    public final boolean isUsingDefaultSelectEffect() {
+        return false;
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/presenters/AlbumDetailsPresenter.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/presenters/AlbumDetailsPresenter.java
@@ -1,0 +1,30 @@
+package com.sregg.android.tv.spotify.presenters;
+
+import android.support.v17.leanback.widget.AbstractDetailsDescriptionPresenter;
+
+import kaaes.spotify.webapi.android.models.Album;
+import kaaes.spotify.webapi.android.models.ArtistSimple;
+
+
+public class AlbumDetailsPresenter extends AbstractDetailsDescriptionPresenter {
+
+    @Override
+    protected void onBindDescription(ViewHolder viewHolder, Object item) {
+        Album album = (Album) item;
+
+        if (album != null) {
+            // artists
+            StringBuilder artists = new StringBuilder();
+            for (ArtistSimple artist : album.artists) {
+                if (artists.length() > 0) {
+                    artists.append(", ");
+                }
+                artists.append(artist.name);
+            }
+
+            viewHolder.getTitle().setText(album.name);
+            viewHolder.getSubtitle().setText(artists);
+            viewHolder.getBody().setText(album.release_date);
+        }
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/presenters/AlbumTrackRowPresenter.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/presenters/AlbumTrackRowPresenter.java
@@ -1,0 +1,26 @@
+package com.sregg.android.tv.spotify.presenters;
+
+import android.support.v17.leanback.widget.RowPresenter;
+import android.text.format.DateUtils;
+
+import com.sregg.android.tv.spotify.rows.TrackRow;
+
+import kaaes.spotify.webapi.android.models.TrackSimple;
+
+public class AlbumTrackRowPresenter extends AbsTrackRowPresenter {
+
+    @Override
+    protected void onBindRowViewHolder(RowPresenter.ViewHolder viewHolder, Object item) {
+        super.onBindRowViewHolder(viewHolder, item);
+
+        TrackRowViewHolder trackViewHolder = (TrackRowViewHolder) viewHolder;
+
+        TrackRow row = (TrackRow) item;
+        TrackSimple track = row.getTrack();
+
+        trackViewHolder.getArtistTextView().setText(null);
+        trackViewHolder.getTrackTextView().setText(track.name);
+        trackViewHolder.getTrackLengthTextView().setText(DateUtils.formatElapsedTime(track.duration_ms / 1000));
+        trackViewHolder.getTrackNumberTextView().setText(String.valueOf(track.track_number));
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/presenters/PlaylistDetailsPresenter.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/presenters/PlaylistDetailsPresenter.java
@@ -1,0 +1,19 @@
+package com.sregg.android.tv.spotify.presenters;
+
+import android.support.v17.leanback.widget.AbstractDetailsDescriptionPresenter;
+
+import kaaes.spotify.webapi.android.models.Playlist;
+
+
+public class PlaylistDetailsPresenter extends AbstractDetailsDescriptionPresenter {
+
+    @Override
+    protected void onBindDescription(ViewHolder viewHolder, Object item) {
+        Playlist playlist = (Playlist) item;
+
+        if (playlist != null) {
+            viewHolder.getTitle().setText(playlist.name);
+            viewHolder.getSubtitle().setText(playlist.description);
+        }
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/presenters/PlaylistTrackRowPresenter.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/presenters/PlaylistTrackRowPresenter.java
@@ -1,0 +1,26 @@
+package com.sregg.android.tv.spotify.presenters;
+
+import android.text.format.DateUtils;
+
+import com.sregg.android.tv.spotify.rows.TrackRow;
+import com.sregg.android.tv.spotify.utils.Utils;
+
+import kaaes.spotify.webapi.android.models.Track;
+
+public class PlaylistTrackRowPresenter extends AbsTrackRowPresenter {
+
+    @Override
+    protected void onBindRowViewHolder(ViewHolder viewHolder, Object item) {
+        super.onBindRowViewHolder(viewHolder, item);
+
+        TrackRowViewHolder trackViewHolder = (TrackRowViewHolder) viewHolder;
+
+        TrackRow row = (TrackRow) item;
+        Track track = (Track) row.getTrack();
+
+        trackViewHolder.getArtistTextView().setText(Utils.getTrackArtists(track));
+        trackViewHolder.getTrackTextView().setText(track.name);
+        trackViewHolder.getTrackLengthTextView().setText(DateUtils.formatElapsedTime(track.duration_ms / 1000));
+        trackViewHolder.getTrackNumberTextView().setText(null);
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/presenters/TracksHeaderRowPresenter.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/presenters/TracksHeaderRowPresenter.java
@@ -1,0 +1,37 @@
+package com.sregg.android.tv.spotify.presenters;
+
+import android.support.v17.leanback.widget.RowPresenter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.sregg.android.tv.spotify.R;
+import com.sregg.android.tv.spotify.views.TrackRowView;
+
+public class TracksHeaderRowPresenter extends RowPresenter {
+    private static final String TAG = "TracksHeaderRowPresenter";
+
+    static class TracksHeaderRowViewHolder extends ViewHolder {
+
+        public TracksHeaderRowViewHolder(View view) {
+            super(view);
+        }
+    }
+
+    public TracksHeaderRowPresenter() {
+        super();
+
+        setHeaderPresenter(null);
+    }
+
+    @Override
+    public TracksHeaderRowViewHolder createRowViewHolder(ViewGroup parent) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.tracks_header_row_view, parent, false);
+        return new TracksHeaderRowViewHolder(view);
+    }
+
+    @Override
+    public final boolean isUsingDefaultSelectEffect() {
+        return false;
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/rows/TrackRow.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/rows/TrackRow.java
@@ -1,0 +1,26 @@
+package com.sregg.android.tv.spotify.rows;
+
+import android.support.v17.leanback.widget.Row;
+
+import kaaes.spotify.webapi.android.models.TrackSimple;
+
+public class TrackRow extends Row {
+
+    private TrackSimple mTrack;
+
+    public TrackRow(TrackSimple track) {
+        super(null);
+        mTrack = track;
+        verify();
+    }
+
+    public TrackSimple getTrack() {
+        return mTrack;
+    }
+
+    private void verify() {
+        if (mTrack == null) {
+            throw new IllegalArgumentException("Tracks cannot be null");
+        }
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/rows/TracksHeaderRow.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/rows/TracksHeaderRow.java
@@ -1,0 +1,6 @@
+package com.sregg.android.tv.spotify.rows;
+
+import android.support.v17.leanback.widget.Row;
+
+public class TracksHeaderRow extends Row {
+}

--- a/app/src/main/java/com/sregg/android/tv/spotify/utils/Utils.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/utils/Utils.java
@@ -7,6 +7,7 @@ import kaaes.spotify.webapi.android.models.ArtistSimple;
 import kaaes.spotify.webapi.android.models.Playlist;
 import kaaes.spotify.webapi.android.models.PlaylistSimple;
 import kaaes.spotify.webapi.android.models.Track;
+import kaaes.spotify.webapi.android.models.TrackSimple;
 
 /**
  * Created by simonreggiani on 15-02-04.
@@ -14,8 +15,8 @@ import kaaes.spotify.webapi.android.models.Track;
 public class Utils {
     public static String getUriFromSpotiyObject(Object spotifyObject) {
         String uri = null;
-        if (spotifyObject instanceof Track) {
-            uri = ((Track) spotifyObject).uri;
+        if (spotifyObject instanceof TrackSimple) {
+            uri = ((TrackSimple) spotifyObject).uri;
         } else if (spotifyObject instanceof Playlist) {
             uri = ((Playlist) spotifyObject).uri;
         } else if (spotifyObject instanceof PlaylistSimple) {
@@ -54,5 +55,10 @@ public class Utils {
             artists.append(artist.name);
         }
         return artists.toString();
+    }
+
+    public static int dpToPx(int dp, Context ctx) {
+        float density = ctx.getResources().getDisplayMetrics().density;
+        return Math.round((float) dp * density);
     }
 }

--- a/app/src/main/java/com/sregg/android/tv/spotify/views/TrackRowView.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/views/TrackRowView.java
@@ -1,0 +1,149 @@
+package com.sregg.android.tv.spotify.views;
+
+import android.content.Context;
+import android.support.v17.leanback.widget.ImageCardView;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.squareup.otto.Subscribe;
+import com.sregg.android.tv.spotify.BusProvider;
+import com.sregg.android.tv.spotify.R;
+import com.sregg.android.tv.spotify.events.AbsPlayingEvent;
+import com.sregg.android.tv.spotify.events.OnPause;
+import com.sregg.android.tv.spotify.events.OnPlay;
+import com.sregg.android.tv.spotify.events.OnTrackEnd;
+import com.sregg.android.tv.spotify.events.OnTrackStart;
+
+public class TrackRowView extends LinearLayout {
+
+    private String mUri;
+    private NowPlayingIndicatorView mNowPlayingView;
+
+    private TextView mArtistTextView;
+    private TextView mTrackTextView;
+    private TextView mTrackLengthTextView;
+    private TextView mTrackNumberTextView;
+
+    public TrackRowView(Context context) {
+        super(context);
+        init();
+    }
+
+    public TrackRowView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public TrackRowView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    public TrackRowView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        init();
+    }
+
+    private void init() {
+        mArtistTextView = (TextView) findViewById(R.id.track_artist);
+        mNowPlayingView = (NowPlayingIndicatorView) findViewById(R.id.track_now_playing);
+        mTrackTextView = (TextView) findViewById(R.id.track_name);
+        mTrackLengthTextView = (TextView) findViewById(R.id.track_length);
+        mTrackNumberTextView = (TextView) findViewById(R.id.track_number);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        BusProvider.getInstance().register(this);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        BusProvider.unregister(this);
+        super.onDetachedFromWindow();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onTrackStart(OnTrackStart onTrackStart) {
+        if (isSelf(onTrackStart)) {
+            initNowPlaying(isSelf(onTrackStart));
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onTrackEnd(OnTrackEnd onTrackEnd) {
+        mNowPlayingView.stopAnimations();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onPlay(OnPlay onPlay) {
+        if (isSelf(onPlay)) {
+            mNowPlayingView.startAnimation();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onPause(OnPause onPause) {
+        if (isSelf(onPause)) {
+            mNowPlayingView.stopAnimations();
+        }
+    }
+
+    private boolean isSelf(AbsPlayingEvent playingEvent) {
+        return isSelf(playingEvent.getCurrentObjectUri());
+    }
+
+    private boolean isSelf(String uri) {
+        return mUri != null && mUri.equals(uri);
+    }
+
+    public void initNowPlaying(boolean isSelf) {
+        if (isSelf) {
+            mNowPlayingView.startAnimation();
+        } else {
+            mNowPlayingView.stopAnimations();
+        }
+    }
+
+    public NowPlayingIndicatorView getNowPlayingView() {
+        return mNowPlayingView;
+    }
+
+    public String getUri() {
+        return mUri;
+    }
+
+    public void setUri(String uri) {
+        mUri = uri;
+    }
+
+    public TextView getArtistTextView() {
+        return mArtistTextView;
+    }
+
+    public TextView getTrackTextView() {
+        return mTrackTextView;
+    }
+
+    public TextView getTrackLengthTextView() {
+        return mTrackLengthTextView;
+    }
+
+    public TextView getTrackNumberTextView() {
+        return mTrackNumberTextView;
+    }
+}

--- a/app/src/main/res/drawable-xhdpi/track_row_background.xml
+++ b/app/src/main/res/drawable-xhdpi/track_row_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="@dimen/lb_details_overview_margin_left"
+    android:insetRight="@dimen/lb_details_overview_margin_right">
+    <ripple android:color="@color/card_info_area_selected_default">
+        <item android:drawable="@color/card_info_area_default" />
+    </ripple>
+</inset>

--- a/app/src/main/res/drawable-xhdpi/tracks_header_row_background.xml
+++ b/app/src/main/res/drawable-xhdpi/tracks_header_row_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="@dimen/lb_details_overview_margin_left"
+    android:insetRight="@dimen/lb_details_overview_margin_right">
+    <shape>
+        <solid android:color="@color/fastlane_background" />
+    </shape>
+
+</inset>

--- a/app/src/main/res/layout/activity_album.xml
+++ b/app/src/main/res/layout/activity_album.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="com.sregg.android.tv.spotify.fragments.AlbumDetailsFragment"
+    android:id="@+id/vertical_grid_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+/>

--- a/app/src/main/res/layout/activity_playlist.xml
+++ b/app/src/main/res/layout/activity_playlist.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="com.sregg.android.tv.spotify.fragments.PlaylistDetailsFragment"
+    android:id="@+id/vertical_grid_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+/>

--- a/app/src/main/res/layout/track_row_view.xml
+++ b/app/src/main/res/layout/track_row_view.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.sregg.android.tv.spotify.views.TrackRowView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/track_row_background"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:orientation="horizontal"
+    android:paddingBottom="8dp"
+    android:paddingTop="8dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+
+        <com.sregg.android.tv.spotify.views.NowPlayingIndicatorView
+            android:id="@+id/track_now_playing"
+            android:layout_width="35dp"
+            android:layout_height="35dp"
+            android:layout_gravity="center"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp" />
+
+        <TextView
+            android:id="@+id/track_number"
+            style="?android:attr/textAppearanceMedium"
+            android:layout_width="32dp"
+            android:layout_height="match_parent"
+            android:layout_marginRight="8dp"
+            android:gravity="center_vertical|right"
+            android:textColor="@android:color/white"
+            tools:text="1" />
+
+        <TextView
+            android:id="@+id/track_name"
+            style="?android:attr/textAppearanceMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginRight="8dp"
+            android:gravity="center"
+            android:textColor="@android:color/white"
+            tools:text="Track Name" />
+
+        <TextView
+            android:id="@+id/track_artist"
+            style="?android:attr/textAppearanceMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginRight="8dp"
+            android:gravity="center"
+            tools:text="Track Artist Name" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/track_length"
+        style="?android:attr/textAppearanceMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_marginRight="8dp"
+        android:gravity="center"
+        tools:text="12:34" />
+
+</com.sregg.android.tv.spotify.views.TrackRowView>

--- a/app/src/main/res/layout/tracks_header_row_view.xml
+++ b/app/src/main/res/layout/tracks_header_row_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/tracks_header_row_background"
+    android:paddingBottom="8dp"
+    android:paddingTop="8dp">
+
+    <TextView
+        style="?android:attr/textAppearanceMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_marginLeft="8dp"
+        android:text="@string/songs"
+        android:textColor="@android:color/white" />
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="settings_quality_low">Low (96 kbit/s)</string>
     <string name="settings_quality_normal">Normal (160 kbit/s)</string>
     <string name="settings_quality_high">High (320 kbit/s)</string>
+    <string name="go_to_artist">Go To Artist</string>
     <plurals name="playlist_nb_tracks">
         <item quantity="zero">no tracks</item>
         <item quantity="one">1 track</item>


### PR DESCRIPTION
Details View for Album and Playlist with look similar to the Google Play Music app.

There are some issues with the background image not being updated always. The layout of long track or artist names aren't perfect and should probably be improved.

There might be some conflicts with the other pull requests, I'll fix anything that won't merge ASAP once any of them are merged into master.

A lot of new code so any feedback is welcome :)

Album Details
![device-2015-05-23-231527](https://cloud.githubusercontent.com/assets/288631/7785789/9f803e40-01a1-11e5-8d8b-d2b310d23076.png)

Album Details Tracks
![device-2015-05-23-230645](https://cloud.githubusercontent.com/assets/288631/7785783/4ae168aa-01a1-11e5-8b07-bec40eaad82d.png)

Playlist Details
![device-2015-05-23-231611](https://cloud.githubusercontent.com/assets/288631/7785792/b7ada03e-01a1-11e5-86bc-8610cb09b9e7.png)
