### PR TITLE
Recommendations Service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,8 +52,11 @@
             android:name=".providers.SearchProvider"
             android:authorities="com.sregg.android.tv.spotify"
             android:enabled="true"
-            android:exported="true" >
-        </provider>
+            android:exported="true" />
+
+        <service
+            android:name=".services.RecommendationsService"
+            android:enabled="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/sregg/android/tv/spotify/activities/MainActivity.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/activities/MainActivity.java
@@ -25,6 +25,7 @@ import com.spotify.sdk.android.authentication.AuthenticationResponse;
 import com.sregg.android.tv.spotify.R;
 import com.sregg.android.tv.spotify.SpotifyTvApplication;
 import com.sregg.android.tv.spotify.controllers.SpotifyPlayerController;
+import com.sregg.android.tv.spotify.services.RecommendationsService;
 import com.sregg.android.tv.spotify.utils.SpotifyUriLoader;
 
 import retrofit.RetrofitError;
@@ -51,6 +52,8 @@ public class MainActivity extends Activity {
 
     private void init() {
         setContentView(R.layout.activity_main);
+
+        startService(new Intent(this, RecommendationsService.class));
 
         if (getIntent() != null && getIntent().getData() != null) {
             SpotifyUriLoader.loadObjectFromUri(SpotifyTvApplication.getInstance().getSpotifyService(), getIntent().getData().toString(), new SpotifyUriLoader.SpotifyObjectLoaderCallback() {

--- a/app/src/main/java/com/sregg/android/tv/spotify/services/RecommendationsService.java
+++ b/app/src/main/java/com/sregg/android/tv/spotify/services/RecommendationsService.java
@@ -1,0 +1,125 @@
+package com.sregg.android.tv.spotify.services;
+
+import android.app.IntentService;
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.TaskStackBuilder;
+import android.text.format.DateFormat;
+import android.util.Log;
+
+import com.squareup.picasso.Picasso;
+import com.sregg.android.tv.spotify.R;
+import com.sregg.android.tv.spotify.SpotifyTvApplication;
+import com.sregg.android.tv.spotify.activities.MainActivity;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import kaaes.spotify.webapi.android.SpotifyService;
+import kaaes.spotify.webapi.android.models.FeaturedPlaylists;
+import kaaes.spotify.webapi.android.models.Playlist;
+import kaaes.spotify.webapi.android.models.PlaylistSimple;
+import kaaes.spotify.webapi.android.models.User;
+
+public class RecommendationsService extends IntentService {
+    private static final String TAG = "RecommendationsService";
+    private static final int MAX_RECOMMENDATIONS = 3;
+
+    private static final int CARD_WIDTH = 274;
+    private static final int CARD_HEIGHT = 274;
+
+    private final NotificationManager mNotificationManager;
+
+    public RecommendationsService() {
+        super(RecommendationsService.class.getSimpleName());
+
+        mNotificationManager = (NotificationManager) SpotifyTvApplication.getInstance().getSystemService(NOTIFICATION_SERVICE);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        Log.d(TAG, "Updating recommendation");
+
+        SpotifyTvApplication app = SpotifyTvApplication.getInstance();
+        SpotifyService spotifyService = app.getSpotifyService();
+        User user = spotifyService.getMe();
+
+        if (user == null) {
+            return;
+        }
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(SpotifyService.COUNTRY, user.country);
+        options.put("timestamp", DateFormat.format("yyyy-MM-dd'T'HH:mm:ss", new Date()));
+        FeaturedPlaylists featuredPlaylists = spotifyService.getFeaturedPlaylists(options);
+
+        if (featuredPlaylists == null) {
+            return;
+        }
+
+        int count = 0;
+
+        for (PlaylistSimple playlistSimple : featuredPlaylists.playlists.items) {
+            Playlist playlist = spotifyService.getPlaylist(playlistSimple.owner.id, playlistSimple.id);
+
+            Log.d(TAG, "Recommendation - Featured Playlist - " + playlist.name);
+
+            mNotificationManager.notify(playlist.id.hashCode(), buildNotification(playlist));
+
+            if (++count >= MAX_RECOMMENDATIONS) {
+                break;
+            }
+        }
+    }
+
+    private Notification buildNotification(Playlist playlist) {
+        Bitmap image = null;
+        if (playlist.images.size() > 0) {
+            try {
+                image = Picasso.with(getApplicationContext())
+                        .load(playlist.images.get(0).url)
+                        .resize(CARD_WIDTH, CARD_HEIGHT)
+                        .centerCrop()
+                        .get();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return new NotificationCompat.BigPictureStyle(
+                new NotificationCompat.Builder(getApplicationContext())
+                        .setContentTitle(playlist.name)
+                        .setContentText(playlist.description)
+                        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                        .setLocalOnly(true)
+                        .setOngoing(true)
+                        .setColor(getResources().getColor(R.color.fastlane_background))
+                        .setCategory(Notification.CATEGORY_RECOMMENDATION)
+                        .setLargeIcon(image)
+                        .setSmallIcon(R.drawable.ic_launcher)
+                        .setContentIntent(buildPendingIntent(playlist.id, playlist.uri))
+                        .setExtras(null))
+                .build();
+    }
+
+    private PendingIntent buildPendingIntent(String id, String itemUri) {
+        Intent detailsIntent = new Intent(this, MainActivity.class);
+        detailsIntent.setData(Uri.parse(itemUri));
+        // Ensure a unique PendingIntents, otherwise all recommendations end up with the same PendingIntent
+        detailsIntent.setAction(id);
+
+        TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
+        stackBuilder.addParentStack(MainActivity.class);
+        stackBuilder.addNextIntent(detailsIntent);
+
+        PendingIntent intent = stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+        return intent;
+    }
+}


### PR DESCRIPTION
A simple Recommendations Service that can easily be extended to support more features and types. Currently it shows the featured playlists for the current timestamp in the logged in user's region. When a recommendation is selected the app starts up, handles auth if needed and then deeplinks into the relevant item, the playlist currently.

Recommendations are updated at app launch. This is due to the way auth is currently handled and can be fixed once auth is persisted and does not need to be initiated by the MainActivity. An AlarmManager can then schedule the RecommendationsService as a repeating alarm so that the recommendations are updated hourly or so.

![device-2015-05-29-011200](https://cloud.githubusercontent.com/assets/288631/7873252/2fbd5658-05a0-11e5-8d90-056714e96d8a.png)
