### PR TITLE
Feature/game controller controls

### DIFF
--- a/app/src/main/java/com/sregg/android/tv/spotifyPlayer/controllers/MediaButtonReceiver.java
+++ b/app/src/main/java/com/sregg/android/tv/spotifyPlayer/controllers/MediaButtonReceiver.java
@@ -1,0 +1,62 @@
+package com.sregg.android.tv.spotifyPlayer.controllers;
+
+import com.sregg.android.tv.spotifyPlayer.enums.Control;
+
+import android.annotation.TargetApi;
+import android.content.Intent;
+import android.media.session.MediaSession;
+import android.os.Build;
+import android.util.Log;
+import android.view.KeyEvent;
+
+/**
+ * Created by gw111zz on 24/01/2016.
+ */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+public class MediaButtonReceiver extends MediaSession.Callback {
+
+    private static final String TAG = "MediaButtonReceiver";
+
+    private final SpotifyPlayerController mPlayer;
+
+    public MediaButtonReceiver(SpotifyPlayerController player) {
+        mPlayer = player;
+    }
+
+    @Override
+    public boolean onMediaButtonEvent(Intent mediaButtonIntent) {
+        final KeyEvent event = (KeyEvent) mediaButtonIntent.getExtras().get(Intent.EXTRA_KEY_EVENT);
+        Log.d(TAG, "onMediaButtonEvent: " + (event == null ? "null" : event));
+
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            final int keyCode = event.getKeyCode();
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_MEDIA_PLAY:
+                    mPlayer.onControlClick(Control.PLAY);
+                    break;
+                case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+                    mPlayer.onControlClick(Control.PREVIOUS);
+                    break;
+                case KeyEvent.KEYCODE_MEDIA_NEXT:
+                    mPlayer.onControlClick(Control.NEXT);
+                    break;
+                case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+                    mPlayer.onControlClick(Control.PAUSE);
+                    break;
+                case KeyEvent.KEYCODE_MEDIA_STOP:
+                    mPlayer.onControlClick(Control.STOP);
+                    break;
+                case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+                    mPlayer.onControlClick(Control.FAST_FORWARD);
+                    break;
+                case KeyEvent.KEYCODE_MEDIA_REWIND:
+                    mPlayer.onControlClick(Control.REWIND);
+                    break;
+                default:
+                    return super.onMediaButtonEvent(mediaButtonIntent);
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/src/main/java/com/sregg/android/tv/spotifyPlayer/controllers/SpotifyPlayerController.java
+++ b/app/src/main/java/com/sregg/android/tv/spotifyPlayer/controllers/SpotifyPlayerController.java
@@ -303,10 +303,11 @@ public class SpotifyPlayerController implements PlayerNotificationCallback, Conn
                 mPlayer.getPlayerState(new PlayerStateCallback() {
                     @Override
                     public void onPlayerState(PlayerState playerState) {
-                        final int rewindPosition = playerState.positionInMs - SKIP_DURATION_MS;
-                        if (rewindPosition < 0) {
-                            mPlayer.skipToPrevious();
+                        final int currentPosition = playerState.positionInMs;
+                        if (currentPosition < SKIP_DURATION_MS) {
+                            mPlayer.seekToPosition(0);
                         } else {
+                            final int rewindPosition = currentPosition - SKIP_DURATION_MS;
                             mPlayer.seekToPosition(rewindPosition);
                         }
                     }

--- a/app/src/main/java/com/sregg/android/tv/spotifyPlayer/enums/Control.java
+++ b/app/src/main/java/com/sregg/android/tv/spotifyPlayer/enums/Control.java
@@ -9,7 +9,9 @@ public enum Control {
     NEXT("{fa-step-forward}"),
     PREVIOUS("{fa-step-backward}"),
     STOP("{fa-stop}"),
-    SHUFFLE("{fa-random}");
+    SHUFFLE("{fa-random}"),
+    FAST_FORWARD("{fa-fast-forward}"),
+    REWIND("{fa-rewind}");
 
     private final String mFontId;
 


### PR DESCRIPTION
Hello!

I've added support for one of the items on your TODO list: Game controller controls (play, pause, previous, next, etc...)

I've added support for play, pause, previous, next, fast-forward and rewind so that playback can be controlled using the TV remote control. Fast-forward and rewind allows the user to jump forwards and backwards 10 seconds respectively. If the user goes past the end of the track then they skip to the start of the next track. If going backwards takes them before the start of the current track, they go to the start of the current track.

I tested this on a Sony Bravia TV.

Regards
