### PR TITLE
Upgrade to Android gradle plugin 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // copied from libraries/spotify-web-api-android/build.gradle
         classpath "org.robolectric:robolectric-gradle-plugin:${ROBOLECTRIC_GRADLE_PLUGIN_VERSION}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,9 @@ BASE_NAME=spotify-web-api-android
 VERSION_NAME=0.1.1
 GROUP=com.spotify.android
 
+#enables dexing in process
+org.gradle.jvmargs = -Xmx2048m
+
 android.useDeprecatedNdk=true
 
 # Deps for gradle


### PR DESCRIPTION
- set gradle property for the Gradle daemon's maximum heap size to 2gb, so that dexing in process is enabled to make incremental and full builds faster
